### PR TITLE
Custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can also configure the location and format of the generated JavaScript file 
 ```ruby
 Js::Routes::Rails.configure do |c|
   c.output = '/some/other/place.js'
-  c.template = 'commonjs'
+  c.template = :commonjs
 end
 ```
 

--- a/lib/js-routes/rails.rb
+++ b/lib/js-routes/rails.rb
@@ -27,7 +27,7 @@ module Js
       def self.default_configuration_options
         {
           output: ::Rails.root.join('app', 'assets', 'javascripts', 'js-routes-rails.js').to_s,
-          template: 'rails'
+          template: :rails
         }
       end
     end

--- a/lib/js-routes/rails/route_exporter.rb
+++ b/lib/js-routes/rails/route_exporter.rb
@@ -27,7 +27,12 @@ module Js
         end
 
         def template_path
-          File.join(template_root, "#{configuration.template}.js")
+          case configuration.template
+          when Symbol
+            File.join(template_root, "#{configuration.template}.js")
+          else
+            configuration.template
+          end
         end
 
         def template_root

--- a/spec/lib/js-routes/rails/route_exporter_spec.rb
+++ b/spec/lib/js-routes/rails/route_exporter_spec.rb
@@ -2,16 +2,18 @@ describe Js::Routes::Rails::RouteExporter do
   let(:routes) { Rails.application.routes.routes }
   let(:finder) { Js::Routes::Rails::RouteFinder.new(routes) }
   subject { described_class.new(finder) }
+  let(:fake_output) { StringIO.new }
+
+  before do
+    output_path = Js::Routes::Rails.configuration.output
+    allow(File).to receive(:open).with(output_path, "w").and_yield(fake_output)
+  end
 
   it "should store a reference to the exportable routes" do
     expect(subject.routes).to eq(finder.routes)
   end
 
   it "should generate a JavaScript file lib containing the routes and output it on disk" do
-    fake_output = StringIO.new
-    output_path = Js::Routes::Rails.configuration.output
-    allow(File).to receive(:open).with(output_path, "w").and_yield(fake_output)
-
     subject.export!
 
     subject.routes.each do |helper, path|
@@ -33,10 +35,6 @@ describe Js::Routes::Rails::RouteExporter do
     it "should render the custom template" do
       fake_template = "Hello world. 1 + 2 = <%= 1 + 2 %>"
       allow(File).to receive(:read).with(template_path).and_return(fake_template)
-
-      fake_output = StringIO.new
-      output_path = Js::Routes::Rails.configuration.output
-      allow(File).to receive(:open).with(output_path, "w").and_yield(fake_output)
 
       subject.export!
       expect(fake_output.string).to eq("Hello world. 1 + 2 = 3")

--- a/spec/lib/js-routes/rails/route_exporter_spec.rb
+++ b/spec/lib/js-routes/rails/route_exporter_spec.rb
@@ -8,8 +8,16 @@ describe Js::Routes::Rails::RouteExporter do
   end
 
   it "should generate a JavaScript file lib containing the routes and output it on disk" do
-    allow(File).to receive(:open).with(/.*app\/assets\/javascripts\/js-routes-rails.js/, "w")
+    fake_output = StringIO.new
+    output_path = Js::Routes::Rails.configuration.output
+    allow(File).to receive(:open).with(output_path, "w").and_yield(fake_output)
+
     subject.export!
+
+    subject.routes.each do |helper, path|
+      expect(fake_output.string).to include(helper)
+      expect(fake_output.string).to include(path)
+    end
   end
 
   context "when configured with a custom template file" do

--- a/spec/lib/js-routes/rails/route_exporter_spec.rb
+++ b/spec/lib/js-routes/rails/route_exporter_spec.rb
@@ -11,4 +11,24 @@ describe Js::Routes::Rails::RouteExporter do
     allow(File).to receive(:open).with(/.*app\/assets\/javascripts\/js-routes-rails.js/, "w")
     subject.export!
   end
+
+  context "when configured with a custom template file" do
+    let(:template_path) { "/foo/bar/template.js" }
+
+    before do
+      Js::Routes::Rails.configuration.template = template_path
+    end
+
+    it "should render the custom template" do
+      fake_template = "Hello world. 1 + 2 = <%= 1 + 2 %>"
+      allow(File).to receive(:read).with(template_path).and_return(fake_template)
+
+      fake_output = StringIO.new
+      output_path = Js::Routes::Rails.configuration.output
+      allow(File).to receive(:open).with(output_path, "w").and_yield(fake_output)
+
+      subject.export!
+      expect(fake_output.string).to eq("Hello world. 1 + 2 = 3")
+    end
+  end
 end

--- a/spec/lib/js-routes/rails/route_exporter_spec.rb
+++ b/spec/lib/js-routes/rails/route_exporter_spec.rb
@@ -15,8 +15,11 @@ describe Js::Routes::Rails::RouteExporter do
   context "when configured with a custom template file" do
     let(:template_path) { "/foo/bar/template.js" }
 
-    before do
+    around do |example|
+      original = Js::Routes::Rails.configuration.template
       Js::Routes::Rails.configuration.template = template_path
+      example.run
+      Js::Routes::Rails.configuration.template = original
     end
 
     it "should render the custom template" do

--- a/spec/lib/js-routes/rails_spec.rb
+++ b/spec/lib/js-routes/rails_spec.rb
@@ -7,16 +7,16 @@ describe Js::Routes::Rails do
 
       it "should default the output template" do
         described_class.configuration = nil
-        expect(described_class.configuration.template).to eq("rails")
+        expect(described_class.configuration.template).to eq(:rails)
       end
     end
 
     it "allow us to override the default configuration object" do
       described_class.configure do |config|
-        config.template = 'commonjs'
+        config.template = :commonjs
       end
 
-      expect(described_class.configuration.template).to eq("commonjs")
+      expect(described_class.configuration.template).to eq(:commonjs)
     end
 
     describe "export!" do


### PR DESCRIPTION
This is an attempt to resolve #1.

Built-in templates are now referenced with symbols, strings are assumed to be custom template paths. This is a backwards incompatible change for those who have manually specified the `template` option.

The code itself is as simple as can be. Testing is a bit more of a challenge, but I got something working by faking [file reads & writes](http://stackoverflow.com/a/33955439/454094) and testing the output.

Let me know what you think, and feel free to tweak the tests if you'd prefer them to be set up differently. ^_^